### PR TITLE
Fix flow draft API route metadata

### DIFF
--- a/api/flow-draft-to-omni/route.ts
+++ b/api/flow-draft-to-omni/route.ts
@@ -225,12 +225,12 @@ export async function POST(req: Request) {
 
 /* Optional: simple GET for health check */
 export async function GET() {
-	return json(200, {
-		ok: true,
-		route: "/app/api/flow-draft-to-omni",
-		requiresSecret: Boolean(env("FLOW_SHARED_SECRET")),
-		hasOmniCreds: Boolean(
-			env("OMNI_USERNAME") && (env("OMNI_API_KEY") || env("OMNI_PASSWORD"))
-		),
-	});
+        return json(200, {
+                ok: true,
+                route: "/api/flow-draft-to-omni",
+                requiresSecret: Boolean(env("FLOW_SHARED_SECRET")),
+                hasOmniCreds: Boolean(
+                        env("OMNI_USERNAME") && (env("OMNI_API_KEY") || env("OMNI_PASSWORD"))
+                ),
+        });
 }


### PR DESCRIPTION
## Summary
- correct the route reported by the flow draft to Omni GET handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vercel dev --listen 0.0.0.0:3000` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d3e151478832c932d47696faf8512