### PR TITLE
feat: allow full draft logging

### DIFF
--- a/api/webhooks/shopify/draft_orders/create.js
+++ b/api/webhooks/shopify/draft_orders/create.js
@@ -7,12 +7,13 @@ const {
 	CIN7_BASE_URL = "https://api.cin7.com/api",
 	CIN7_USERNAME,
 	CIN7_API_KEY,
-	CIN7_BRANCH_ID,
-	CIN7_DEFAULT_CURRENCY = "USD",
-	LOG_SHOPIFY_SUMMARY = "0",
-	DEBUG_DRY_RUN = "0",
-	LOG_SHOPIFY_RAW = "0",
-	DEBUG_TOKEN,
+        CIN7_BRANCH_ID,
+        CIN7_DEFAULT_CURRENCY = "USD",
+        LOG_SHOPIFY_SUMMARY = "0",
+        LOG_SHOPIFY_DRAFT = "0",
+        DEBUG_DRY_RUN = "0",
+        LOG_SHOPIFY_RAW = "0",
+        DEBUG_TOKEN,
 } = process.env;
 
 if (!SHOPIFY_APP_SECRET) console.error("Missing SHOPIFY_APP_SECRET");
@@ -180,18 +181,31 @@ export default async function handler(req, res) {
 	if (LOG_SHOPIFY_RAW === "1") capture.raw = rawBody.toString("utf8");
 	recordEvent(capture);
 
-	if (LOG_SHOPIFY_SUMMARY === "1") {
-		console.log(
-			JSON.stringify({
-				tag: "shopify.draft.summary",
-				reqId,
-				shop,
-				topic,
-				triggeredAt,
-				draft: summarizeDraft(draft),
-			})
-		);
-	}
+        if (LOG_SHOPIFY_SUMMARY === "1") {
+                console.log(
+                        JSON.stringify({
+                                tag: "shopify.draft.summary",
+                                reqId,
+                                shop,
+                                topic,
+                                triggeredAt,
+                                draft: summarizeDraft(draft),
+                        })
+                );
+        }
+
+        if (LOG_SHOPIFY_DRAFT === "1") {
+                console.log(
+                        JSON.stringify({
+                                tag: "shopify.draft.full",
+                                reqId,
+                                shop,
+                                topic,
+                                triggeredAt,
+                                draft,
+                        })
+                );
+        }
 
 	try {
 		const quote = mapDraftOrderToCin7Quote(draft);

--- a/scripts/send-signed.js
+++ b/scripts/send-signed.js
@@ -62,6 +62,7 @@ const {
   CIN7_BRANCH_ID,
   CIN7_DEFAULT_CURRENCY = 'USD',
   LOG_SHOPIFY_SUMMARY = '0',
+  LOG_SHOPIFY_DRAFT = '0',
   DEBUG_DRY_RUN = '0',
   LOG_SHOPIFY_RAW = '0',
   WEBHOOK_DUMP_DIR = '.webhook_dumps',
@@ -218,6 +219,7 @@ app.post('/webhooks/shopify/draft_orders/create', rawJson, async (req, res) => {
     if (LOG_SHOPIFY_RAW === '1') dumpToFile(capture);
 
     if (LOG_SHOPIFY_SUMMARY === '1') console.log(JSON.stringify({ tag: 'shopify.draft.summary', draft: summarizeDraft(draft) }));
+    if (LOG_SHOPIFY_DRAFT === '1') console.log(JSON.stringify({ tag: 'shopify.draft.full', draft }));
 
     const quote = mapDraftOrderToCin7Quote(draft);
 

--- a/src/server.js
+++ b/src/server.js
@@ -11,11 +11,12 @@ const {
 	CIN7_BASE_URL = "https://api.cin7.com/api",
 	CIN7_USERNAME,
 	CIN7_API_KEY,
-	CIN7_BRANCH_ID,
-	CIN7_DEFAULT_CURRENCY = "USD",
-	LOG_SHOPIFY_SUMMARY = "0",
-	DEBUG_DRY_RUN = "0",
-	PORT = 3000,
+        CIN7_BRANCH_ID,
+        CIN7_DEFAULT_CURRENCY = "USD",
+        LOG_SHOPIFY_SUMMARY = "0",
+        LOG_SHOPIFY_DRAFT = "0",
+        DEBUG_DRY_RUN = "0",
+        PORT = 3000,
 } = process.env;
 
 if (!SHOPIFY_APP_SECRET) throw new Error("Missing SHOPIFY_APP_SECRET");
@@ -153,14 +154,23 @@ app.post("/webhooks/shopify/draft_orders/create", rawJson, async (req, res) => {
 			JSON.parse(req.body.toString("utf8")).draft_order ||
 			JSON.parse(req.body.toString("utf8"));
 
-		if (LOG_SHOPIFY_SUMMARY === "1") {
-			console.log(
-				JSON.stringify({
-					tag: "shopify.draft.summary",
-					draft: summarizeDraft(draft),
-				})
-			);
-		}
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        console.log(
+                                JSON.stringify({
+                                        tag: "shopify.draft.summary",
+                                        draft: summarizeDraft(draft),
+                                })
+                        );
+                }
+
+                if (LOG_SHOPIFY_DRAFT === "1") {
+                        console.log(
+                                JSON.stringify({
+                                        tag: "shopify.draft.full",
+                                        draft,
+                                })
+                        );
+                }
 
 		const quote = mapDraftOrderToCin7Quote(draft);
 


### PR DESCRIPTION
## Summary
- add `LOG_SHOPIFY_DRAFT` env var to enable logging of full Shopify draft objects
- log complete draft payloads for webhook handler, local server, and send-signed script when enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d70fe5684832c8c2dd6083a720da2