### PR TITLE
Populate email and discount fields for Cin7 quotes

### DIFF
--- a/api/webhooks/shopify/draft_orders/create.js
+++ b/api/webhooks/shopify/draft_orders/create.js
@@ -2,13 +2,15 @@ import crypto from "crypto";
 import axios from "axios";
 
 const {
-	SHOPIFY_APP_SECRET,
-	SHOPIFY_ALLOWED_SHOP,
-	CIN7_BASE_URL = "https://api.cin7.com/api",
-	CIN7_USERNAME,
-	CIN7_API_KEY,
-	CIN7_BRANCH_ID,
-	CIN7_DEFAULT_CURRENCY = "USD",
+        SHOPIFY_APP_SECRET,
+        SHOPIFY_ALLOWED_SHOP,
+        CIN7_BASE_URL = "https://api.cin7.com/api",
+        CIN7_USERNAME,
+        CIN7_API_KEY,
+        CIN7_BRANCH_ID,
+        CIN7_DEFAULT_CURRENCY = "USD",
+        LOG_SHOPIFY_SUMMARY = "0",
+        DEBUG_DRY_RUN = "0",
 } = process.env;
 
 if (!SHOPIFY_APP_SECRET) console.error("Missing SHOPIFY_APP_SECRET");
@@ -43,31 +45,36 @@ function verifyShopifyHmac(rawBody, headers) {
 }
 
 function allowedShop(headers) {
-	if (!SHOPIFY_ALLOWED_SHOP) return true;
-	const shop =
-		headers["x-shopify-shop-domain"] || headers["X-Shopify-Shop-Domain"];
-	return shop && shop.toLowerCase() === SHOPIFY_ALLOWED_SHOP.toLowerCase();
+        if (!SHOPIFY_ALLOWED_SHOP) return true;
+        const shop =
+                headers["x-shopify-shop-domain"] || headers["X-Shopify-Shop-Domain"];
+        return shop && shop.toLowerCase() === SHOPIFY_ALLOWED_SHOP.toLowerCase();
+}
+
+function logJson(level, tag, data) {
+        console[level](`[${tag}]`, JSON.stringify({ tag, ...data }));
 }
 
 export function mapDraftOrderToCin7Quote(draft) {
-	const cust = draft.customer || {};
-	const ship = draft.shipping_address || {};
-	const bill = draft.billing_address || {};
-	const primaryEmail =
-		draft.email || cust.email || bill.email || ship.email || null;
-	const quote = {
-		reference: draft.name || String(draft.id || ""),
-		firstName: cust.first_name || bill.first_name || ship.first_name || "",
-		lastName: cust.last_name || bill.last_name || ship.last_name || "",
-		company:
-			bill.company || ship.company || (cust.default_address?.company ?? ""),
-		email: primaryEmail || undefined,
-		phone: ship.phone || bill.phone || cust.phone || "",
-		deliveryFirstName: ship.first_name || "",
-		deliveryLastName: ship.last_name || "",
-		deliveryCompany: ship.company || "",
-		deliveryAddress1: ship.address1 || "",
-		deliveryAddress2: ship.address2 || "",
+        const cust = draft.customer || {};
+        const ship = draft.shipping_address || {};
+        const bill = draft.billing_address || {};
+        const primaryEmail =
+                draft.email || cust.email || bill.email || ship.email || null;
+        const quote = {
+                reference: draft.name || String(draft.id || ""),
+                firstName: cust.first_name || bill.first_name || ship.first_name || "",
+                lastName: cust.last_name || bill.last_name || ship.last_name || "",
+                company:
+                        bill.company || ship.company || (cust.default_address?.company ?? ""),
+                memberEmail: primaryEmail || undefined,
+                email: primaryEmail || undefined,
+                phone: ship.phone || bill.phone || cust.phone || "",
+                deliveryFirstName: ship.first_name || "",
+                deliveryLastName: ship.last_name || "",
+                deliveryCompany: ship.company || "",
+                deliveryAddress1: ship.address1 || "",
+                deliveryAddress2: ship.address2 || "",
 		deliveryCity: ship.city || "",
 		deliveryState: ship.province || "",
 		deliveryPostalCode: ship.zip || "",
@@ -92,22 +99,33 @@ export function mapDraftOrderToCin7Quote(draft) {
 			draft.applied_discount?.title ||
 			draft.applied_discount?.description ||
 			null,
-		lineItems: (draft.line_items || []).map((li, idx) => ({
-			code: li.sku || "",
-			name: li.title || "",
-			option1: li.variant_title || "",
-			qty: Number(li.quantity || 0),
-			unitPrice: li.price != null ? Number(li.price) : 0,
-			discount: li.applied_discount?.amount
-				? Number(li.applied_discount.amount)
-				: 0,
-			sort: idx + 1,
-		})),
-	};
-	Object.keys(quote).forEach((k) => {
-		if (quote[k] === undefined || quote[k] === null || quote[k] === "")
-			delete quote[k];
-	});
+                lineItems: (draft.line_items || []).map((li, idx) => {
+                        const discountValue = li.applied_discount?.amount
+                                ? Number(li.applied_discount.amount)
+                                : 0;
+                        const discountRate =
+                                discountValue && li.price
+                                        ? (discountValue / Number(li.price)) * 100
+                                        : 0;
+                        const line = {
+                                code: li.sku || "",
+                                name: li.title || "",
+                                option1: li.variant_title || "",
+                                qty: Number(li.quantity || 0),
+                                unitPrice: li.price != null ? Number(li.price) : 0,
+                                sort: idx + 1,
+                        };
+                        if (discountValue) {
+                                line.discount = discountRate;
+                                line.discountValue = discountValue;
+                        }
+                        return line;
+                }),
+        };
+        Object.keys(quote).forEach((k) => {
+                if (quote[k] === undefined || quote[k] === null || quote[k] === "")
+                        delete quote[k];
+        });
 	return quote;
 }
 
@@ -174,42 +192,33 @@ export default async function handler(req, res) {
 	capture.raw = rawBody.toString("utf8");
 	recordEvent(capture);
 
-	console.log(
-		JSON.stringify({
-			tag: "shopify.draft.summary",
-			reqId,
-			shop,
-			topic,
-			triggeredAt,
-			draft: summarizeDraft(draft),
-		})
-	);
+        logJson("log", "shopify.draft.summary", {
+                reqId,
+                shop,
+                topic,
+                triggeredAt,
+                draft: summarizeDraft(draft),
+        });
 
-	console.log(
-		JSON.stringify({
-			tag: "shopify.draft.full",
-			reqId,
-			shop,
-			topic,
-			triggeredAt,
-			draft,
-		})
-	);
+        logJson("log", "shopify.draft.full", {
+                reqId,
+                shop,
+                topic,
+                triggeredAt,
+                draft,
+        });
 
 	try {
 		const quote = mapDraftOrderToCin7Quote(draft);
 
-		if (!quote.memberEmail) {
-			console.warn(
-				JSON.stringify({
-					tag: "cin7.precondition.missingEmail",
-					reqId,
-					reference: quote.reference,
-					note: "No email found on draft/customer; Cin7 requires email when memberId is not provided.",
-				})
-			);
-			return res.status(200).send("ok");
-		}
+                if (!quote.memberEmail) {
+                        logJson("warn", "cin7.precondition.missingEmail", {
+                                reqId,
+                                reference: quote.reference,
+                                note: "No email found on draft/customer; Cin7 requires email when memberId is not provided.",
+                        });
+                        return res.status(200).send("ok");
+                }
 
 		try {
 			const r = await axios.get(`${CIN7_BASE_URL}/v1/Contacts`, {
@@ -223,30 +232,24 @@ export default async function handler(req, res) {
 			});
 			const contact = Array.isArray(r.data) ? r.data[0] : null;
 			if (contact?.id) quote.memberId = contact.id;
-		} catch (e) {
-			console.warn(
-				JSON.stringify({
-					tag: "cin7.contact.lookup.failed",
-					reqId,
-					status: e.response?.status,
-					message: e.message,
-				})
-			);
-		}
+                } catch (e) {
+                        logJson("warn", "cin7.contact.lookup.failed", {
+                                reqId,
+                                status: e.response?.status,
+                                message: e.message,
+                        });
+                }
 
-		if (LOG_SHOPIFY_SUMMARY === "1") {
-			console.log(
-				JSON.stringify({
-					tag: "cin7.quote.preview",
-					reqId,
-					reference: quote.reference,
-					hasEmail: !!quote.email,
-					memberId: quote.memberId || 0,
-					lineCount: quote.lineItems?.length || 0,
-					codes: (quote.lineItems || []).map((l) => l.code).filter(Boolean),
-				})
-			);
-		}
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        logJson("log", "cin7.quote.preview", {
+                                reqId,
+                                reference: quote.reference,
+                                hasEmail: !!quote.memberEmail,
+                                memberId: quote.memberId || 0,
+                                lineCount: quote.lineItems?.length || 0,
+                                codes: (quote.lineItems || []).map((l) => l.code).filter(Boolean),
+                        });
+                }
 
 		if (DEBUG_DRY_RUN === "1") return res.status(200).send("ok");
 
@@ -258,23 +261,20 @@ export default async function handler(req, res) {
 			timeout: 10000,
 		});
 
-		if (LOG_SHOPIFY_SUMMARY === "1") {
-			console.log(
-				JSON.stringify({
-					tag: "cin7.quote.created",
-					reqId,
-					reference: quote.reference,
-				})
-			);
-		}
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        logJson("log", "cin7.quote.created", {
+                                reqId,
+                                reference: quote.reference,
+                        });
+                }
 
 		return res.status(200).send("ok");
-	} catch (err) {
-		console.error(
-			"Cin7 error",
-			err.response?.status,
-			err.response?.data?.message || err.message
-		);
-		return res.status(502).send("cin7 error");
-	}
+        } catch (err) {
+                logJson("error", "cin7.quote.create.failed", {
+                        reqId,
+                        status: err.response?.status,
+                        message: err.response?.data?.message || err.message,
+                });
+                return res.status(502).send("cin7 error");
+        }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -6,14 +6,16 @@ import express from "express";
 dotenv.config();
 
 const {
-	SHOPIFY_APP_SECRET,
-	SHOPIFY_ALLOWED_SHOP,
-	CIN7_BASE_URL = "https://api.cin7.com/api",
-	CIN7_USERNAME,
-	CIN7_API_KEY,
-	CIN7_BRANCH_ID,
-	CIN7_DEFAULT_CURRENCY = "USD",
-	PORT = 3000,
+        SHOPIFY_APP_SECRET,
+        SHOPIFY_ALLOWED_SHOP,
+        CIN7_BASE_URL = "https://api.cin7.com/api",
+        CIN7_USERNAME,
+        CIN7_API_KEY,
+        CIN7_BRANCH_ID,
+        CIN7_DEFAULT_CURRENCY = "USD",
+        LOG_SHOPIFY_SUMMARY = "0",
+        DEBUG_DRY_RUN = "0",
+        PORT = 3000,
 } = process.env;
 
 if (!SHOPIFY_APP_SECRET) throw new Error("Missing SHOPIFY_APP_SECRET");
@@ -42,65 +44,83 @@ function verifyShopifyHmac(rawBody, headers) {
 }
 
 function allowedShop(headers) {
-	if (!SHOPIFY_ALLOWED_SHOP) return true;
-	const shop =
-		headers["x-shopify-shop-domain"] || headers["X-Shopify-Shop-Domain"];
-	return shop && shop.toLowerCase() === SHOPIFY_ALLOWED_SHOP.toLowerCase();
+        if (!SHOPIFY_ALLOWED_SHOP) return true;
+        const shop =
+                headers["x-shopify-shop-domain"] || headers["X-Shopify-Shop-Domain"];
+        return shop && shop.toLowerCase() === SHOPIFY_ALLOWED_SHOP.toLowerCase();
+}
+
+function logJson(level, tag, data) {
+        console[level](`[${tag}]`, JSON.stringify({ tag, ...data }));
 }
 
 function mapDraftOrderToCin7Quote(draft) {
-	const cust = draft.customer || {};
-	const ship = draft.shipping_address || {};
-	const bill = draft.billing_address || {};
-	const quote = {
-		reference: draft.name || String(draft.id || ""),
-		firstName: cust.first_name || bill.first_name || ship.first_name || "",
-		lastName: cust.last_name || bill.last_name || ship.last_name || "",
-		company:
-			bill.company || ship.company || (cust.default_address?.company ?? ""),
-		email: draft.email || cust.email || "",
-		phone: ship.phone || bill.phone || cust.phone || "",
-		deliveryFirstName: ship.first_name || "",
-		deliveryLastName: ship.last_name || "",
-		deliveryCompany: ship.company || "",
-		deliveryAddress1: ship.address1 || "",
-		deliveryAddress2: ship.address2 || "",
-		deliveryCity: ship.city || "",
-		deliveryState: ship.province || "",
-		deliveryPostalCode: ship.zip || "",
-		deliveryCountry: ship.country || "",
-		billingFirstName: bill.first_name || "",
-		billingLastName: bill.last_name || "",
-		billingCompany: bill.company || "",
-		billingAddress1: bill.address1 || "",
-		billingAddress2: bill.address2 || "",
-		billingCity: bill.city || "",
-		billingPostalCode: bill.zip || "",
-		billingState: bill.province || "",
-		billingCountry: bill.country || "",
-		branchId: CIN7_BRANCH_ID ? Number(CIN7_BRANCH_ID) : undefined,
-		internalComments: draft.note || null,
-		currencyCode: draft.currency || CIN7_DEFAULT_CURRENCY,
-		taxStatus: draft.taxes_included ? "Incl" : "Excl",
-		discountTotal: draft.applied_discount?.amount
-			? Number(draft.applied_discount.amount)
-			: 0,
-		discountDescription:
-			draft.applied_discount?.title ||
-			draft.applied_discount?.description ||
-			null,
-		lineItems: (draft.line_items || []).map((li, idx) => ({
-			code: li.sku || "",
-			name: li.title || "",
-			option1: li.variant_title || "",
-			qty: Number(li.quantity || 0),
-			unitPrice: li.price != null ? Number(li.price) : 0,
-			discount: li.applied_discount?.amount
-				? Number(li.applied_discount.amount)
-				: 0,
-			sort: idx + 1,
-		})),
-	};
+        const cust = draft.customer || {};
+        const ship = draft.shipping_address || {};
+        const bill = draft.billing_address || {};
+        const primaryEmail =
+                draft.email || cust.email || bill.email || ship.email || null;
+        const quote = {
+                reference: draft.name || String(draft.id || ""),
+                firstName: cust.first_name || bill.first_name || ship.first_name || "",
+                lastName: cust.last_name || bill.last_name || ship.last_name || "",
+                company:
+                        bill.company || ship.company || (cust.default_address?.company ?? ""),
+                memberEmail: primaryEmail || undefined,
+                email: primaryEmail || undefined,
+                phone: ship.phone || bill.phone || cust.phone || "",
+                deliveryFirstName: ship.first_name || "",
+                deliveryLastName: ship.last_name || "",
+                deliveryCompany: ship.company || "",
+                deliveryAddress1: ship.address1 || "",
+                deliveryAddress2: ship.address2 || "",
+                deliveryCity: ship.city || "",
+                deliveryState: ship.province || "",
+                deliveryPostalCode: ship.zip || "",
+                deliveryCountry: ship.country || "",
+                billingFirstName: bill.first_name || "",
+                billingLastName: bill.last_name || "",
+                billingCompany: bill.company || "",
+                billingAddress1: bill.address1 || "",
+                billingAddress2: bill.address2 || "",
+                billingCity: bill.city || "",
+                billingPostalCode: bill.zip || "",
+                billingState: bill.province || "",
+                billingCountry: bill.country || "",
+                branchId: CIN7_BRANCH_ID ? Number(CIN7_BRANCH_ID) : undefined,
+                internalComments: draft.note || null,
+                currencyCode: draft.currency || CIN7_DEFAULT_CURRENCY,
+                taxStatus: draft.taxes_included ? "Incl" : "Excl",
+                discountTotal: draft.applied_discount?.amount
+                        ? Number(draft.applied_discount.amount)
+                        : 0,
+                discountDescription:
+                        draft.applied_discount?.title ||
+                        draft.applied_discount?.description ||
+                        null,
+                lineItems: (draft.line_items || []).map((li, idx) => {
+                        const discountValue = li.applied_discount?.amount
+                                ? Number(li.applied_discount.amount)
+                                : 0;
+                        const discountRate =
+                                discountValue && li.price
+                                        ? (discountValue / Number(li.price)) * 100
+                                        : 0;
+                        const line = {
+                                code: li.sku || "",
+                                name: li.title || "",
+                                option1: li.variant_title || "",
+                                qty: Number(li.quantity || 0),
+                                unitPrice: li.price != null ? Number(li.price) : 0,
+                                sort: idx + 1,
+                        };
+                        if (discountValue) {
+                                line.discount = discountRate;
+                                line.discountValue = discountValue;
+                        }
+                        return line;
+                }),
+        };
 	Object.keys(quote).forEach((k) => {
 		if (quote[k] === undefined || quote[k] === null || quote[k] === "")
 			delete quote[k];
@@ -142,43 +162,35 @@ const rawJson = express.raw({ type: "application/json" });
 app.get("/healthz", (_req, res) => res.status(200).send("ok"));
 
 app.post("/webhooks/shopify/draft_orders/create", rawJson, async (req, res) => {
-	try {
-		if (!allowedShop(req.headers)) return res.status(401).send("invalid shop");
-		if (!verifyShopifyHmac(req.body, req.headers))
-			return res.status(401).send("invalid hmac");
+        const reqId = crypto.randomUUID();
+        try {
+                if (!allowedShop(req.headers)) return res.status(401).send("invalid shop");
+                if (!verifyShopifyHmac(req.body, req.headers))
+                        return res.status(401).send("invalid hmac");
 
-		const draft =
-			JSON.parse(req.body.toString("utf8")).draft_order ||
-			JSON.parse(req.body.toString("utf8"));
+                const draft =
+                        JSON.parse(req.body.toString("utf8")).draft_order ||
+                        JSON.parse(req.body.toString("utf8"));
 
-		if (LOG_SHOPIFY_SUMMARY === "1") {
-			console.log(
-				JSON.stringify({
-					tag: "shopify.draft.summary",
-					draft: summarizeDraft(draft),
-				})
-			);
-		}
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        logJson("log", "shopify.draft.summary", {
+                                reqId,
+                                draft: summarizeDraft(draft),
+                        });
+                }
 
-		console.log(
-			JSON.stringify({
-				tag: "shopify.draft.full",
-				draft,
-			})
-		);
+                logJson("log", "shopify.draft.full", { reqId, draft });
 
 		const quote = mapDraftOrderToCin7Quote(draft);
 
-		if (!quote.memberEmail) {
-			console.warn(
-				JSON.stringify({
-					tag: "cin7.precondition.missingEmail",
-					reference: quote.reference,
-					note: "No email found on draft/customer; Cin7 requires email when memberId is not provided.",
-				})
-			);
-			return res.status(200).send("ok");
-		}
+                if (!quote.memberEmail) {
+                        logJson("warn", "cin7.precondition.missingEmail", {
+                                reqId,
+                                reference: quote.reference,
+                                note: "No email found on draft/customer; Cin7 requires email when memberId is not provided.",
+                        });
+                        return res.status(200).send("ok");
+                }
 
 		// Try to resolve memberId by email
 		try {
@@ -193,40 +205,47 @@ app.post("/webhooks/shopify/draft_orders/create", rawJson, async (req, res) => {
 			});
 			const contact = Array.isArray(r.data) ? r.data[0] : null;
 			if (contact?.id) quote.memberId = contact.id;
-		} catch (e) {
-			console.warn(
-				JSON.stringify({
-					tag: "cin7.contact.lookup.failed",
-					status: e.response?.status,
-					message: e.message,
-				})
-			);
-		}
+                } catch (e) {
+                        logJson("warn", "cin7.contact.lookup.failed", {
+                                reqId,
+                                status: e.response?.status,
+                                message: e.message,
+                        });
+                }
 
-		if (DEBUG_DRY_RUN === "1") return res.status(200).send("ok");
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        logJson("log", "cin7.quote.preview", {
+                                reqId,
+                                reference: quote.reference,
+                                hasEmail: !!quote.memberEmail,
+                                memberId: quote.memberId || 0,
+                                lineCount: quote.lineItems?.length || 0,
+                                codes: (quote.lineItems || []).map((l) => l.code).filter(Boolean),
+                        });
+                }
 
-		await sendQuoteToCin7(quote);
+                if (DEBUG_DRY_RUN === "1") return res.status(200).send("ok");
 
-		if (LOG_SHOPIFY_SUMMARY === "1") {
-			console.log(
-				JSON.stringify({
-					tag: "cin7.quote.created",
-					reference: quote.reference,
-				})
-			);
-		}
+                await sendQuoteToCin7(quote);
+
+                if (LOG_SHOPIFY_SUMMARY === "1") {
+                        logJson("log", "cin7.quote.created", {
+                                reqId,
+                                reference: quote.reference,
+                        });
+                }
 
 		return res.status(200).send("ok");
-	} catch (err) {
-		console.error(
-			"Webhook handler error:",
-			err.response?.status,
-			err.response?.data || err.message
-		);
-		return res.status(200).send("ok");
-	}
+        } catch (err) {
+                logJson("error", "webhook.handler.error", {
+                        reqId,
+                        status: err.response?.status,
+                        message: err.response?.data || err.message,
+                });
+                return res.status(200).send("ok");
+        }
 });
 
 app.listen(Number(PORT), () => {
-	console.log(`Webhook server listening on :${PORT}`);
+        logJson("log", "server.listen", { port: Number(PORT) });
 });


### PR DESCRIPTION
## Summary
- Map customer email to `memberEmail` to satisfy Cin7 preconditions
- Capture line-item discount value and percentage when building Cin7 quotes
- Prefix JSON logs with tags for clearer console output

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689eb17a99c0832cbf5bf8f2ea18cc68